### PR TITLE
Feat/packet forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ It has a simple but complete GUI built with [imgui-go](https://github.com/inkybl
 
 Please report any bug or request new features by filing and issue.
 
+This program was also extended to generate raw PACKET FORWARDER UDP-based protocol as alternative transport, to be used with general LoRaWAN netfork server (e.g. [lorawan-server](https://github.com/gotthardp/lorawan-server)). Use `forwarder` configuration section to enable.
+
 ![](images/new-gui.png?raw=true)
 
 ### Requirements
@@ -113,6 +115,10 @@ log_level = "info"
 [window]
   width = 1200
   height = 1000
+
+[forwarder]
+  nserver = "192.168.5.71"
+  nsport = "1680"
 ```
 You may also import files located at `working-dir/confs` and save to the same directory.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It has a simple but complete GUI built with [imgui-go](https://github.com/inkybl
 
 Please report any bug or request new features by filing and issue.
 
-This program was also extended to generate raw PACKET FORWARDER UDP-based protocol as alternative transport, to be used with general LoRaWAN netfork server (e.g. [lorawan-server](https://github.com/gotthardp/lorawan-server)). Use `forwarder` configuration section to enable.
+This program was also extended to generate raw PACKET FORWARDER UDP-based protocol as alternative transport, to be used with general LoRaWAN network server (e.g. [lorawan-server](https://github.com/gotthardp/lorawan-server)). Use `forwarder` configuration section to enable.
 
 ![](images/new-gui.png?raw=true)
 

--- a/device.go
+++ b/device.go
@@ -499,8 +499,8 @@ func run() {
 		}
 
 		//Now send an uplink
-		var ulfc uint32 = 0
-		err = nil
+		var ulfc uint32
+		
 		if !cNSClient.Connected {
 			ulfc, err = cDevice.Uplink(mqttClient, config.MQTT.UplinkTopic, config.Device.MType, uint8(config.RawPayload.FPort), &urx, &utx, payload, config.GW.MAC, config.Band.Name, dataRate, fOpts, fCtrl)
 		} else {

--- a/device.go
+++ b/device.go
@@ -243,6 +243,7 @@ func setDevice() {
 		joinNonceEdit = int(cDevice.JoinNonce)
 		joinNonceEditS = strconv.Itoa(joinNonceEdit)
 	} else {
+		log.Info("Device reset")
 		cDevice.Reset()
 	}
 }

--- a/device.go
+++ b/device.go
@@ -384,7 +384,7 @@ func join() {
 
 func run() {
 
-	if !NSClient.Connected {
+	if !cNSClient.Connected {
 		if mqttClient == nil {
 			err := connectClient()
 			if err != nil {
@@ -500,10 +500,10 @@ func run() {
 		//Now send an uplink
 		var ulfc uint32 = 0
 		err = nil
-		if !NSClient.Connected {
+		if !cNSClient.Connected {
 			ulfc, err = cDevice.Uplink(mqttClient, config.MQTT.UplinkTopic, config.Device.MType, uint8(config.RawPayload.FPort), &urx, &utx, payload, config.GW.MAC, config.Band.Name, dataRate, fOpts, fCtrl)
 		} else {
-			ulfc, err = cDevice.UplinkUDP(NSClient.Server, NSClient.Port, config.Device.MType, uint8(config.RawPayload.FPort), &urx, &utx, payload, config.GW.MAC, config.Band.Name, dataRate, fOpts, fCtrl)
+			ulfc, err = cDevice.UplinkUDP(cNSClient, config.Device.MType, uint8(config.RawPayload.FPort), &urx, &utx, payload, config.GW.MAC, config.Band.Name, dataRate, fOpts, fCtrl)
 		}
 
 		if err != nil {

--- a/forwarder.go
+++ b/forwarder.go
@@ -56,7 +56,7 @@ func forwarderConnect() error {
 
 func forwarderDisconnect() error {
 	cNSClient.Connected = false
-	log.Infoln("UDP Forwarder STopped (MQTT back again)")
+	log.Infoln("UDP Forwarder stopped (MQTT back again)")
 
 	return nil
 }

--- a/forwarder.go
+++ b/forwarder.go
@@ -1,14 +1,19 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/inkyblackness/imgui-go"
 	log "github.com/sirupsen/logrus"
 )
 
 type nsclient struct {
 	Connected bool
+	Server string
+	Port int
 }
 
+// NSClient is a direct NetworkServer connection handle
 var NSClient nsclient
 
 type forwarder struct {
@@ -38,15 +43,25 @@ func beginForwarderForm() {
 }
 
 func forwarderConnect() error {
+	port, err := strconv.Atoi(config.Forwarder.Port)
+
+	if err != nil {
+		log.Warn("Bad Network server UDP port")
+		return err
+	}
+
+	NSClient.Server = config.Forwarder.Server
+	NSClient.Port = port
 	NSClient.Connected = true
-	log.Infoln("UDP Forwared Started")
+	log.Infoln("UDP Forwarder Started (MQTT disabled)")
 	// TODO subscribe to downlinks
 
 	return nil
 }
 
 func forwarderDisconnect() error {
-	log.Infoln("UDP Forwared Stopped")
+	NSClient.Connected = false
+	log.Infoln("UDP Forwarder Stopped (MQTT back again")
 
 	return nil
 }

--- a/forwarder.go
+++ b/forwarder.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/inkyblackness/imgui-go"
+	log "github.com/sirupsen/logrus"
+)
+
+type nsclient struct {
+	Connected bool
+}
+
+var NSClient nsclient
+
+type forwarder struct {
+	Server		string `toml:"nserver"`
+	Port		string `toml:"nsport"`
+}
+
+func beginForwarderForm() {
+	imgui.Begin("Forwarder")
+	imgui.Separator()
+	imgui.PushItemWidth(250.0)
+	imgui.InputText("Network Server", &config.Forwarder.Server)
+	imgui.InputText("UDP Port", &config.Forwarder.Port)
+
+	if imgui.Button("Connect") {
+		forwarderConnect()
+	}
+	if NSClient.Connected {
+		if imgui.Button("Disconnect") {
+			forwarderDisconnect()
+		}
+	}
+	//Add popus for file administration.
+	beginOpenFile()
+	beginSaveFile()
+	imgui.End()
+}
+
+func forwarderConnect() error {
+	NSClient.Connected = true
+	log.Infoln("UDP Forwared Started")
+	// TODO subscribe to downlinks
+
+	return nil
+}
+
+func forwarderDisconnect() error {
+	log.Infoln("UDP Forwared Stopped")
+
+	return nil
+}
+

--- a/forwarder.go
+++ b/forwarder.go
@@ -5,16 +5,11 @@ import (
 
 	"github.com/inkyblackness/imgui-go"
 	log "github.com/sirupsen/logrus"
+	"github.com/iegomez/lds/lds"
 )
 
-type nsclient struct {
-	Connected bool
-	Server string
-	Port int
-}
-
-// NSClient is a direct NetworkServer connection handle
-var NSClient nsclient
+// cNSClient is a direct NetworkServer connection handle
+var cNSClient lds.NSClient
 
 type forwarder struct {
 	Server		string `toml:"nserver"`
@@ -31,7 +26,7 @@ func beginForwarderForm() {
 	if imgui.Button("Connect") {
 		forwarderConnect()
 	}
-	if NSClient.Connected {
+	if cNSClient.Connected {
 		if imgui.Button("Disconnect") {
 			forwarderDisconnect()
 		}
@@ -50,9 +45,9 @@ func forwarderConnect() error {
 		return err
 	}
 
-	NSClient.Server = config.Forwarder.Server
-	NSClient.Port = port
-	NSClient.Connected = true
+	cNSClient.Server = config.Forwarder.Server
+	cNSClient.Port = port
+	cNSClient.Connected = true
 	log.Infoln("UDP Forwarder Started (MQTT disabled)")
 	// TODO subscribe to downlinks
 
@@ -60,7 +55,7 @@ func forwarderConnect() error {
 }
 
 func forwarderDisconnect() error {
-	NSClient.Connected = false
+	cNSClient.Connected = false
 	log.Infoln("UDP Forwarder Stopped (MQTT back again")
 
 	return nil

--- a/forwarder.go
+++ b/forwarder.go
@@ -41,14 +41,14 @@ func forwarderConnect() error {
 	port, err := strconv.Atoi(config.Forwarder.Port)
 
 	if err != nil {
-		log.Warn("Bad Network server UDP port")
+		log.Warn("network server UDP port must be a number")
 		return err
 	}
 
 	cNSClient.Server = config.Forwarder.Server
 	cNSClient.Port = port
 	cNSClient.Connected = true
-	log.Infoln("UDP Forwarder Started (MQTT disabled)")
+	log.Infoln("UDP Forwarder started (MQTT disabled)")
 	// TODO subscribe to downlinks
 
 	return nil
@@ -56,7 +56,7 @@ func forwarderConnect() error {
 
 func forwarderDisconnect() error {
 	cNSClient.Connected = false
-	log.Infoln("UDP Forwarder Stopped (MQTT back again")
+	log.Infoln("UDP Forwarder STopped (MQTT back again)")
 
 	return nil
 }

--- a/imgui.ini
+++ b/imgui.ini
@@ -14,8 +14,8 @@ Size=380,170
 Collapsed=0
 
 [Window][Device]
-Pos=10,204
-Size=382,433
+Pos=11,388
+Size=382,249
 Collapsed=0
 
 [Window][Data]
@@ -36,5 +36,10 @@ Collapsed=1
 [Window][LoRa Server device provisioner]
 Pos=60,60
 Size=993,621
+Collapsed=0
+
+[Window][Forwarder]
+Pos=10,200
+Size=379,179
 Collapsed=0
 

--- a/imgui.ini
+++ b/imgui.ini
@@ -1,25 +1,25 @@
 [Window][LoRa Configuration]
-Pos=12,645
+Pos=12,646
 Size=380,265
 Collapsed=0
 
 [Window][Output]
-Pos=401,644
+Pos=397,654
 Size=780,265
 Collapsed=0
 
 [Window][MQTT & Gateway]
-Pos=10,25
+Pos=5,30
 Size=380,170
 Collapsed=0
 
 [Window][Device]
-Pos=11,388
+Pos=13,377
 Size=382,249
 Collapsed=0
 
 [Window][Data]
-Pos=400,285
+Pos=398,283
 Size=781,354
 Collapsed=0
 

--- a/lds/lds.go
+++ b/lds/lds.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
-	"encoding/base64"
 	"fmt"
 	"math"
 	"strconv"
@@ -174,6 +173,8 @@ func (d *Device) marshalPhyPayload(mType lorawan.MType, fPort uint8, rxInfo *gw.
 		fOpts[i] = macCommands[i]
 	}
 
+	log.Infof("Device address %v", d.DevAddr)
+
 	phy := lorawan.PHYPayload{
 		MHDR: lorawan.MHDR{
 			MType: mType,
@@ -328,10 +329,7 @@ func (d *Device) UplinkUDP(cClient NSClient, mType lorawan.MType, fPort uint8, r
 
 	log.Debugf("marshaled PHY payload: %v\n", string(phyBytes))
 
-	phyBase := base64.StdEncoding.EncodeToString(phyBytes)
-	message := []byte(phyBase)
-
-	err = cClient.send(message)
+	err = cClient.sendWithPayload(phyBytes, gwMAC, rxInfo, txInfo)
 	if err != nil {
 		log.Debugf("Unable to send UDP datagram: %s\n", err)
 		return d.UlFcnt, err

--- a/lds/nsclient.go
+++ b/lds/nsclient.go
@@ -1,0 +1,36 @@
+package lds
+
+import (
+	"net"
+	"errors"
+)
+
+// NSClient is a raw UDP client
+type NSClient struct {
+	Connected bool
+	Server string
+	Port int
+}
+
+func (client *NSClient) send(bytes []byte) error {
+	ip := net.ParseIP(client.Server)
+
+	if ip == nil {
+		return errors.New("bad network server IP")
+	}
+
+	addr := net.UDPAddr{
+		IP:   ip,
+		Port: client.Port,
+	}
+
+	conn, err := net.DialUDP("udp", nil, &addr)
+ 
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write(bytes)
+	return err
+}

--- a/lds/nsclient.go
+++ b/lds/nsclient.go
@@ -2,7 +2,18 @@ package lds
 
 import (
 	"net"
+	"fmt"
+	"time"
 	"errors"
+	"math/rand"
+	"bytes"
+	"encoding/json"
+	"encoding/base64"
+	"encoding/hex"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/brocaar/loraserver/api/gw"
 )
 
 // NSClient is a raw UDP client
@@ -10,6 +21,26 @@ type NSClient struct {
 	Connected bool
 	Server string
 	Port int
+}
+
+type pfpacket struct {
+	Time string		`json:"time"`
+	TMST uint64		`json:"tmst"`
+	Chan uint32		`json:"chan"`
+	RFCH uint32		`json:"rfch"`
+	Freq float32	`json:"freq"`
+	Stat int32		`json:"stat"`
+	Modu string		`json:"modu"`
+	DatR string		`json:"datr"`
+	CorR string		`json:"codr"`
+	RSSI int32		`json:"rssi"`
+	LSNR float64	`json:"lsnr"`
+	Size uint32		`json:"size"`
+	Data string		`json:"data"`
+}
+
+type pfproto struct {
+	RXPK []pfpacket		`json:"rxpk"`
 }
 
 func (client *NSClient) send(bytes []byte) error {
@@ -33,4 +64,62 @@ func (client *NSClient) send(bytes []byte) error {
 
 	_, err = conn.Write(bytes)
 	return err
+}
+
+func toMilliseconds(d *duration.Duration) uint64 {
+	return uint64(d.Seconds) * 1000 + uint64(d.Nanos) / 1000
+}
+
+func (client *NSClient) sendWithPayload(payload []byte, gwMAC string, rxInfo *gw.UplinkRXInfo, txInfo *gw.UplinkTXInfo) error {
+
+	phyBase := base64.StdEncoding.EncodeToString(payload)
+
+	gps := rxInfo.GetTimeSinceGpsEpoch()
+	utc := time.Now().Format(time.RFC3339)
+	mod := txInfo.GetLoraModulationInfo()
+
+	packet := pfpacket{}
+	packet.Time = utc
+	packet.TMST = toMilliseconds(gps)
+	packet.Chan = rxInfo.GetChannel()
+	packet.RFCH = rxInfo.GetRfChain()
+	packet.Freq = float32(txInfo.GetFrequency()) / 1000000.0
+	packet.Stat = 1
+	packet.Modu = "LORA"
+	packet.DatR = fmt.Sprintf("SF%dBW%d", mod.SpreadingFactor, mod.GetBandwidth())
+	packet.CorR = mod.GetCodeRate()
+	packet.RSSI = rxInfo.GetRssi()
+	packet.LSNR = rxInfo.GetLoraSnr()
+	packet.Size = uint32(len(payload))
+	packet.Data = phyBase
+
+	proto := pfproto { RXPK: []pfpacket{ packet } }
+
+	packetJSON, err := json.Marshal(proto)
+
+	log.Infof("Marshalled upstream JSON %s", packetJSON)
+
+	if err != nil {
+		return err
+	}
+
+	version := byte(0x02)
+	token := rand.Int()
+	tokenlsb := byte(token & 0x00FF)
+	tokenmsb := byte((token & 0xFF00) >> 8)
+	id := byte(0x00)
+	header := []byte{ version, tokenmsb, tokenlsb, id }
+
+	gwbytes, err := hex.DecodeString(gwMAC)
+
+	if err != nil {
+		return err
+	}
+
+	jsonbytes := []byte(packetJSON)
+	datagram := bytes.Join([][]byte{header, gwbytes, jsonbytes}, []byte{})
+
+	client.send(datagram)
+
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ type windowConf struct {
 
 type tomlConfig struct {
 	MQTT        mqtt           `toml:"mqtt"`
+	Forwarder   forwarder      `toml:"forwarder"`
 	Band        band           `toml:"band"`
 	Device      device         `toml:"device"`
 	GW          gateway        `toml:"gateway"`
@@ -97,6 +98,8 @@ func importConf() {
 	if config == nil {
 		cMqtt := mqtt{}
 
+		cForwarder := forwarder{}
+
 		cGw := gateway{}
 
 		cDev := device{
@@ -124,6 +127,7 @@ func importConf() {
 
 		config = &tomlConfig{
 			MQTT:        cMqtt,
+			Forwarder:   cForwarder,
 			Band:        cBand,
 			Device:      cDev,
 			GW:          cGw,
@@ -367,6 +371,7 @@ func main() {
 		impl.NewFrame()
 
 		beginMQTTForm()
+		beginForwarderForm()
 		beginDeviceForm()
 		beginLoRaForm()
 		beginControl()


### PR DESCRIPTION
Added support for Semtech `packet forwarder` protocol to be used with a generic network server (not only chirpstack), which receives data via UDP. To the date, only unconfirmed uplinks are supported. UDP reception could be quite easily implemented as well, if needed by anyone.

BTW, thank you for a great tool.