### PR TITLE
Adding scripts to create executables with github-actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,32 @@
+name: 'Compile binary'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 'Deployment with ssh'
+    runs-on: windows-2019
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: .
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Compile go
+      env:
+          GOROOT_1_14_X64: 1
+          GOEXE: .exe
+      run: make
+
+    - name: Save compiled file
+      uses: actions/upload-artifact@v2
+      with:
+        name: gui
+        path: gui.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Releases
+
+on: 
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "gui"
+        body: "LoRa Simulator release"
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,40 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-2019
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: .
+
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Compile go
+      env:
+          GOROOT_1_14_X64: 1
+          GOEXE: .exe
+      run: make
+
+    - name: Save compiled file
+      uses: actions/upload-artifact@v2
+      with:
+        name: gui
+        path: gui.exe
+        
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download result from build
+      uses: actions/download-artifact@v2
+      with:
+        name: gui
+
     - uses: ncipollo/release-action@v1
       with:
-        artifacts: "gui"
+        artifacts: "gui,gui.exe"
         body: "LoRa Simulator release"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add scripts to create executables:
- Create the executable for Windows.
- Automate the process with each release and add as artifact.

Closes #32 